### PR TITLE
doc: fix git submodule path

### DIFF
--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -60,7 +60,7 @@ project directory.
   ansible_managed     = Warning: File is managed by Ansible [https://github.com/adfinis-sygroup/ansible-roles]
   retry_files_enabled = False
   hostfile            = ./hosts
-  roles_path          = ./adsy-roles
+  roles_path          = ./adfinis-roles
 
   [ssh_connection]
   ssh_args            = -o ControlMaster=auto -o ControlPersist=30s
@@ -107,7 +107,7 @@ be accepted. Follow the guidelines for new roles.
 To create special roles for one project (e.g. not possible as a generic
 role or never needed in another project) put them inside the directory
 ``roles/``. Each role in this directory will override roles in the directory
-``adsy-roles/``.
+``adfinis-roles/``.
 
 
 .. _ansible-roles: https://github.com/adfinis-sygroup/ansible-roles

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -12,8 +12,8 @@ information, check out the
 Directory and file structure
 ============================
 The Ansible Project publishes a `Best Practices
-<http://docs.ansible.com/ansible/playbooks_best_practices.html>`_ 
-our guideline is an extension to that guide. 
+<http://docs.ansible.com/ansible/playbooks_best_practices.html>`_
+our guideline is an extension to that guide.
 
 ::
 
@@ -41,7 +41,7 @@ our guideline is an extension to that guide.
   │       ├── ntp.yml
   │       └── ssh.yml
   ├── roles/
-  ├── adsy-roles/
+  ├── adfinis-roles/
   │   ├── ntp/
   │   │   ├── defaults/
   │   │   │   └── main.yml


### PR DESCRIPTION
As we moved git submodule from adsy-roles to adfinis-roles.