### PR TITLE
GitLab CI: use image python:3 to make sphinx documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # python
 *.pyc
 /.venv/
+/.python-version
 
 # documentation
 /doc/_build/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,11 @@
 ---
 # -*- coding: utf-8 -*-
 
+image: python:3
+
 before_script:
   - git submodule update --init
+  - pip install sphinx
 
 stages:
   - doc


### PR DESCRIPTION
I fixed the GitLab CI configuration for our new CI environment.

The GitLab project is a mirror of the GitHub project and is used to build the documentation.