### PR TITLE
GitLab CI: add sphinx_rtd_theme as dependency

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ image: python:3
 
 before_script:
   - git submodule update --init
-  - pip install sphinx
+  - pip install sphinx sphinx_rtd_theme
 
 stages:
   - doc


### PR DESCRIPTION
I forgot the pip dependency sphinx_rtd_theme.