### PR TITLE
fix group vars for network setup

### DIFF
--- a/group_vars/all/network.yml
+++ b/group_vars/all/network.yml
@@ -8,7 +8,4 @@ network_interfaces:
   - device: eth0
     tmpl: ethernet
     force: True
-    ipv4:
-      type: dhcp
-    ipv6:
-      type: manual
+    ipv4_dhcp: yes


### PR DESCRIPTION
This should be changed because the network templates where changed in the past.