### PR TITLE
clone adsy sphinx template in gitlabci manually

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,6 +28,7 @@ build-sphinx:
   stage: doc
   script:
     - mkdir ansible-guide
+    - git clone https://github.com/adfinis-sygroup/adsy-sphinx-template doc/sphinx-template
     - make clean || true
     - make doc
     - mv doc/_build/html/* ansible-guide


### PR DESCRIPTION
The adsy sphinx template didn't exist, so I add a line to clone the repository manually in the gitlab ci configuration.