### PR TITLE
fix GitLab CI build chain

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@ cache:
 
 before_script:
   - if [ -d ../lint-rules/.git ]; then
-      cd ../lint-rules && git fetch -p && git pull;
+      cd ../lint-rules && git pull --rebase ; cd -;
     else
       git clone https://github.com/adfinis-sygroup/ansible-lint-rules ../lint-rules;
     fi


### PR DESCRIPTION
There is a bug in the GitLab CI build chain. We need the build chain in the GitLab CI to build and upload the documentation. This PR will fix this issue (already tested).