### PR TITLE
chore: name[prefix] for included task names

### DIFF
--- a/doc/roles_collections.rst
+++ b/doc/roles_collections.rst
@@ -104,7 +104,7 @@ installation and configuration components.  Tasks inside the
 
   ---
 
-  - name: Install SSH-related packages
+  - name: install | Install SSH-related packages
     ansible.builtin.package:
       name: "{{ sshd_packages }}"
       state: present
@@ -115,7 +115,7 @@ The configuration files are rendered in ``config.yml``:
 
   ---
 
-  - name: Create SSH authorized_keys directory
+  - name: config | Create SSH authorized_keys directory
     ansible.builtin.file:
       path: /etc/ssh/authorized_keys
       state: directory
@@ -127,7 +127,7 @@ The configuration files are rendered in ``config.yml``:
       setype: sshd_key_t
       selevel: s0
 
-  - name: Configure SSHd
+  - name: config | Configure SSHd
     ansible.builtin.template:
       src: etc/ssh/sshd_config.j2
       dest: "{{ sshd_daemon_cfg }}"
@@ -151,7 +151,7 @@ Good example:
 
 .. code-block:: Yaml
 
-  - name: Install SSH related packages
+  - name: install | Install SSH related packages
     ansible.builtin.package:
       name: "{{ sshd_packages }}"
       state: present
@@ -166,7 +166,7 @@ Bad example:
 
 .. code-block:: Yaml
 
-  - name: Install SSH related packages
+  - name: install | Install SSH related packages
     ansible.builtin.package:
       name: "{{ sshd_packages }}"
       state: present
@@ -369,7 +369,7 @@ Good example:
 
   ---
 
-  - name: Configure the ssh daemon
+  - name: config | Configure the ssh daemon
     ansible.builtin.template:
       src: etc/ssh/sshd_config.j2
       dest: "{{ sshd_daemon_cfg }}"

--- a/doc/styling_guide.rst
+++ b/doc/styling_guide.rst
@@ -28,6 +28,10 @@ Tasks
 - Each task has a empty line above the task.
 - Tasks have a name which contains only letters, numbers
   and spaces.  Task names start with an uppercase letter.
+- Tasks from an included task file should be named with a prefix, consisting
+  of its file name. For example the task `Deploy config`
+  in ``tasks/deploy.yml`` should be named ``deploy | Deploy config``
+  rather than just ``Deploy config``.
 - Module names are written as FQCN wherever possible.
 - Each argument of a module is on its own line.
 - Key and value are separated by colon and space.


### PR DESCRIPTION
Update guide to follow ansible-lint's name[prefix] rule, which adds a prefix to all tasks in included task files. For example the prefix `config |` for tasks in `tasks/config.yml`. Example:
```yaml
---
# tasks file for tasks/config.yml

- name: config | Setup configuration
  ansible.builtin.template:
  ...
```

Refs: https://ansible.readthedocs.io/projects/lint/rules/name/#nameprefix