### PR TITLE
fix(doc): install/config.yml task file names

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -51,8 +51,8 @@ Our guideline is an extension to that guide.
   │   │   ├── meta/
   │   │   │   └── main.yml
   │   │   ├── tasks/
-  │   │   │   ├── configuration.yml
-  │   │   │   ├── installation.yml
+  │   │   │   ├── config.yml
+  │   │   │   ├── install.yml
   │   │   │   └── main.yml
   │   │   ├── templates/
   │   │   │   └── etc/
@@ -72,8 +72,8 @@ Our guideline is an extension to that guide.
   │       ├── meta/
   │       │   └── main.yml
   │       ├── tasks/
-  │       │   ├── configuration.yml
-  │       │   ├── installation.yml
+  │       │   ├── config.yml
+  │       │   ├── install.yml
   │       │   └── main.yml
   │       ├── templates/
   │       │   └── etc/

--- a/doc/roles_collections.rst
+++ b/doc/roles_collections.rst
@@ -49,8 +49,8 @@ Role Directory Layout
   ├── meta/
   │   └── main.yml
   ├── tasks/
-  │   ├── configuration.yml
-  │   ├── installation.yml
+  │   ├── config.yml
+  │   ├── install.yml
   │   └── main.yml
   ├── templates/
   │   └── etc/


### PR DESCRIPTION
Use install/config.yml instead of installation/configuration.yml, as it's described in the guidelines.